### PR TITLE
chore(governance): permission-denied hardening + firestore rules same-sha production gate

### DIFF
--- a/.github/workflows/deploy-firestore-rules.yml
+++ b/.github/workflows/deploy-firestore-rules.yml
@@ -1,0 +1,95 @@
+name: Deploy Firestore Rules
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: "Commit SHA to deploy Firestore rules from"
+        required: true
+        type: string
+      reason:
+        description: "Why this rules deployment is requested"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-firestore-rules
+  cancel-in-progress: false
+
+jobs:
+  deploy-firestore-rules:
+    name: deploy-firestore-rules
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout target SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.target_sha }}
+
+      - name: Verify checkout SHA matches target
+        id: verify_sha
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          target_sha="${{ github.event.inputs.target_sha }}"
+          if [[ "$actual_sha" != "$target_sha" ]]; then
+            echo "::error::Checkout SHA mismatch (actual=$actual_sha, target=$target_sha)"
+            exit 1
+          fi
+          echo "actual_sha=$actual_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Configure Firebase auth
+        id: auth
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${FIREBASE_SERVICE_ACCOUNT:-}" ]]; then
+            credentials_path="$RUNNER_TEMP/firebase-service-account.json"
+            printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$credentials_path"
+            echo "GOOGLE_APPLICATION_CREDENTIALS=$credentials_path" >> "$GITHUB_ENV"
+            echo "auth_mode=service_account" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ -n "${FIREBASE_TOKEN:-}" ]]; then
+            echo "FIREBASE_TOKEN=$FIREBASE_TOKEN" >> "$GITHUB_ENV"
+            echo "auth_mode=firebase_token" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::error::Missing Firebase credentials. Set FIREBASE_SERVICE_ACCOUNT or FIREBASE_TOKEN secret."
+          exit 1
+
+      - name: Deploy firestore.rules
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          project_id="${FIREBASE_PROJECT_ID:-sale-zone-601f0}"
+          firebase deploy --only firestore:rules --project "$project_id" --non-interactive
+
+      - name: Deployment summary
+        run: |
+          {
+            echo "## Firestore Rules Deployment"
+            echo "- target_sha: \`${{ github.event.inputs.target_sha }}\`"
+            echo "- actual_sha: \`${{ steps.verify_sha.outputs.actual_sha }}\`"
+            echo "- deployed_rules_file: \`firestore.rules\`"
+            echo "- reason: ${{ github.event.inputs.reason }}"
+            echo "- timestamp_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "- auth_mode: ${{ steps.auth.outputs.auth_mode }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -51,7 +51,7 @@ jobs:
             echo "checklist_path=release/release-checklist.json" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Ensure release gate and staging succeeded for target SHA
+      - name: Ensure release gate, staging, and firestore rules deploy succeeded for target SHA
         uses: actions/github-script@v7
         env:
           TARGET_SHA: ${{ steps.sha.outputs.value }}
@@ -60,7 +60,8 @@ jobs:
             const targetSha = process.env.TARGET_SHA;
             const requiredWorkflows = [
               { id: "release-gate.yml", label: "Release Gate" },
-              { id: "deploy-staging.yml", label: "Deploy Staging" }
+              { id: "deploy-staging.yml", label: "Deploy Staging" },
+              { id: "deploy-firestore-rules.yml", label: "Deploy Firestore Rules" }
             ];
             let stagingSuccessRun = null;
 

--- a/RELEASE_GATE_POLICY.md
+++ b/RELEASE_GATE_POLICY.md
@@ -59,10 +59,14 @@ Runner:
 - Staging writes metadata file:
   - `output/staging-metadata.json`
   - fields: `targetSha`, `actualSha`, `createdAt`
+- Firestore rules must be deployed from the same SHA before production:
+  - workflow: `.github/workflows/deploy-firestore-rules.yml`
+  - input: `target_sha`
 - Production validates checkout SHA explicitly:
   - `git rev-parse HEAD` must match `target_sha`
 - Production checks that staging artifact exists for the same SHA:
   - `staging-<target_sha>`
+- Production also checks that `deploy-firestore-rules.yml` has a successful run on the same SHA.
 
 ## Periodic Sabotage Tests (Not Daily)
 Run these periodically (weekly) and on every `policy-change:` PR:
@@ -74,14 +78,15 @@ These are system validity checks, not per-push checks.
 ## Staging and Production Flow
 1. Merge PR with green checks.
 2. Run `Deploy Staging` on target SHA.
-3. Observe staging for 24 hours:
+3. Run `Deploy Firestore Rules` on the same target SHA.
+4. Observe staging for 24 hours:
    - `client_error_logs`
    - `store_events`
    - critical failures
    - drift findings
    - error spikes
-4. Promote to Production using the exact same SHA.
-5. Post-production watch:
+5. Promote to Production using the exact same SHA.
+6. Post-production watch:
    - first 30 minutes deep watch
    - regular review during first 24 hours
 

--- a/firebase-api.js
+++ b/firebase-api.js
@@ -1659,11 +1659,11 @@ function subscribeStoreEvents(onData, onError, limitCount = 100) {
                     if (typeof onData === 'function') onData(rows);
                 },
                 (error) => {
-                    if (typeof onError === 'function') onError(error);
+                    if (typeof onError === 'function') onError(normalizeFirebaseError(error, 'subscribeStoreEvents.listener'));
                 }
             );
     } catch (e) {
-        if (typeof onError === 'function') onError(e);
+        if (typeof onError === 'function') onError(normalizeFirebaseError(e, 'subscribeStoreEvents.setup'));
         return null;
     }
 }
@@ -1741,11 +1741,11 @@ function subscribeLiveSessions(onData, onError, limitCount = 200) {
                     if (typeof onData === 'function') onData(rows);
                 },
                 (error) => {
-                    if (typeof onError === 'function') onError(error);
+                    if (typeof onError === 'function') onError(normalizeFirebaseError(error, 'subscribeLiveSessions.listener'));
                 }
             );
     } catch (e) {
-        if (typeof onError === 'function') onError(e);
+        if (typeof onError === 'function') onError(normalizeFirebaseError(e, 'subscribeLiveSessions.setup'));
         return null;
     }
 }
@@ -2048,11 +2048,11 @@ function subscribeSupportThreads(onData, onError, limitCount = 100) {
                     if (typeof onData === 'function') onData(rows);
                 },
                 (error) => {
-                    if (typeof onError === 'function') onError(error);
+                    if (typeof onError === 'function') onError(normalizeFirebaseError(error, 'subscribeSupportThreads.listener'));
                 }
             );
     } catch (e) {
-        if (typeof onError === 'function') onError(e);
+        if (typeof onError === 'function') onError(normalizeFirebaseError(e, 'subscribeSupportThreads.setup'));
         return null;
     }
 }
@@ -2071,11 +2071,11 @@ function subscribeSupportThread(threadId, onData, onError) {
                     }
                 },
                 (error) => {
-                    if (typeof onError === 'function') onError(error);
+                    if (typeof onError === 'function') onError(normalizeFirebaseError(error, 'subscribeSupportThread.listener'));
                 }
             );
     } catch (e) {
-        if (typeof onError === 'function') onError(e);
+        if (typeof onError === 'function') onError(normalizeFirebaseError(e, 'subscribeSupportThread.setup'));
         return null;
     }
 }
@@ -2097,11 +2097,11 @@ function subscribeSupportMessages(threadId, onData, onError, limitCount = 200) {
                     if (typeof onData === 'function') onData(rows);
                 },
                 (error) => {
-                    if (typeof onError === 'function') onError(error);
+                    if (typeof onError === 'function') onError(normalizeFirebaseError(error, 'subscribeSupportMessages.listener'));
                 }
             );
     } catch (e) {
-        if (typeof onError === 'function') onError(e);
+        if (typeof onError === 'function') onError(normalizeFirebaseError(e, 'subscribeSupportMessages.setup'));
         return null;
     }
 }

--- a/monitoring/admin-function-registry.json
+++ b/monitoring/admin-function-registry.json
@@ -1,15 +1,15 @@
 {
   "generatorVersion": "1.0.0",
-  "generatedAt": "2026-02-17T04:06:00.797Z",
+  "generatedAt": "2026-02-17T16:59:30.803Z",
   "sourceFile": "ادمن_2.HTML",
   "policyFile": "monitoring/admin-function-policy.json",
-  "sourceHash": "ec22c1f07e4f83281df04b51f26b3d98bcd1eae74dbf825a81ebd6a3018f4875",
+  "sourceHash": "43c614dc89a87ab3c13884b49db10d5eef61435bfd546c75a1853b0e62eb6779",
   "policyHash": "21916e642fd098fb48953ad7499534b0b8b158a786c8ea91f5aadbee472eddc4",
   "functions": [
     {
       "name": "adminLogout",
       "isAsync": false,
-      "line": 3038,
+      "line": 3052,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -23,7 +23,7 @@
     {
       "name": "analyzeSheetForImportCompatibility",
       "isAsync": false,
-      "line": 6398,
+      "line": 6589,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -37,7 +37,7 @@
     {
       "name": "applyAdminFunctionFilters",
       "isAsync": false,
-      "line": 6045,
+      "line": 6236,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -51,7 +51,7 @@
     {
       "name": "applyAutoTooltips",
       "isAsync": false,
-      "line": 7142,
+      "line": 7333,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -65,7 +65,7 @@
     {
       "name": "applyLocalProductUpdate",
       "isAsync": false,
-      "line": 3508,
+      "line": 3529,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -79,7 +79,7 @@
     {
       "name": "applyLocalProductVisibility",
       "isAsync": false,
-      "line": 3521,
+      "line": 3542,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -93,7 +93,7 @@
     {
       "name": "applyProductOpOnline",
       "isAsync": true,
-      "line": 2482,
+      "line": 2496,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -107,7 +107,7 @@
     {
       "name": "assignSupplierToSelectionPrompt",
       "isAsync": true,
-      "line": 4200,
+      "line": 4221,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -121,7 +121,7 @@
     {
       "name": "autoPurgeSamplesOnce",
       "isAsync": true,
-      "line": 7312,
+      "line": 7503,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -135,7 +135,7 @@
     {
       "name": "buildColumnMapping",
       "isAsync": false,
-      "line": 6570,
+      "line": 6761,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -149,7 +149,7 @@
     {
       "name": "buildProductPayloadFromForm",
       "isAsync": false,
-      "line": 3451,
+      "line": 3472,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -163,7 +163,7 @@
     {
       "name": "buildProductSearchTokensSafe",
       "isAsync": false,
-      "line": 2368,
+      "line": 2382,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -175,9 +175,23 @@
       "reasonText": "تم تسجيل الدالة ضمن المتابعة."
     },
     {
+      "name": "canUseStoreOps",
+      "isAsync": false,
+      "line": 5912,
+      "scriptIndex": 0,
+      "group": "utility",
+      "monitorLevel": "info",
+      "storeImpact": "none",
+      "mobileImpact": "none",
+      "persistenceMode": "memory_only",
+      "status": "ok",
+      "reasonCode": "BASELINE_OK",
+      "reasonText": "تم تسجيل الدالة ضمن المتابعة."
+    },
+    {
       "name": "canUseSupportChat",
       "isAsync": false,
-      "line": 5090,
+      "line": 5138,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -191,7 +205,7 @@
     {
       "name": "changeAdminPassword",
       "isAsync": true,
-      "line": 7060,
+      "line": 7251,
       "scriptIndex": 0,
       "group": "settings",
       "monitorLevel": "warning",
@@ -205,7 +219,7 @@
     {
       "name": "checkAdminSession",
       "isAsync": false,
-      "line": 2992,
+      "line": 3006,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -219,7 +233,7 @@
     {
       "name": "checkAppVersionAndRefresh",
       "isAsync": true,
-      "line": 2567,
+      "line": 2581,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -233,7 +247,21 @@
     {
       "name": "clearAllData",
       "isAsync": false,
-      "line": 7051,
+      "line": 7242,
+      "scriptIndex": 0,
+      "group": "utility",
+      "monitorLevel": "info",
+      "storeImpact": "none",
+      "mobileImpact": "none",
+      "persistenceMode": "memory_only",
+      "status": "ok",
+      "reasonCode": "BASELINE_OK",
+      "reasonText": "تم تسجيل الدالة ضمن المتابعة."
+    },
+    {
+      "name": "clearStoreOpsAccessState",
+      "isAsync": false,
+      "line": 5879,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -247,7 +275,7 @@
     {
       "name": "clearSupportAccessState",
       "isAsync": false,
-      "line": 5056,
+      "line": 5104,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -261,7 +289,7 @@
     {
       "name": "clearSupportMessageSubscription",
       "isAsync": false,
-      "line": 5235,
+      "line": 5283,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -275,7 +303,7 @@
     {
       "name": "clearSupportThreadSubscription",
       "isAsync": false,
-      "line": 5242,
+      "line": 5290,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -289,7 +317,7 @@
     {
       "name": "closeActiveSupportThread",
       "isAsync": true,
-      "line": 5417,
+      "line": 5484,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -303,7 +331,7 @@
     {
       "name": "closeModal",
       "isAsync": false,
-      "line": 7174,
+      "line": 7365,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -317,7 +345,7 @@
     {
       "name": "commitImportBatch",
       "isAsync": true,
-      "line": 6872,
+      "line": 7063,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -331,7 +359,7 @@
     {
       "name": "copyPreflightReport",
       "isAsync": false,
-      "line": 7448,
+      "line": 7639,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -345,7 +373,7 @@
     {
       "name": "createEmptyImportWizardState",
       "isAsync": false,
-      "line": 6174,
+      "line": 6365,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -359,7 +387,7 @@
     {
       "name": "deleteAllProducts",
       "isAsync": true,
-      "line": 3732,
+      "line": 3753,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "critical",
@@ -373,7 +401,7 @@
     {
       "name": "deleteBanner",
       "isAsync": true,
-      "line": 4691,
+      "line": 4712,
       "scriptIndex": 0,
       "group": "banners",
       "monitorLevel": "critical",
@@ -387,7 +415,7 @@
     {
       "name": "deleteCoupon",
       "isAsync": true,
-      "line": 4795,
+      "line": 4816,
       "scriptIndex": 0,
       "group": "coupons",
       "monitorLevel": "critical",
@@ -401,7 +429,7 @@
     {
       "name": "deleteCustomer",
       "isAsync": true,
-      "line": 4987,
+      "line": 5008,
       "scriptIndex": 0,
       "group": "users",
       "monitorLevel": "warning",
@@ -415,7 +443,7 @@
     {
       "name": "deleteOrder",
       "isAsync": true,
-      "line": 4616,
+      "line": 4637,
       "scriptIndex": 0,
       "group": "orders",
       "monitorLevel": "critical",
@@ -429,7 +457,7 @@
     {
       "name": "deleteProduct",
       "isAsync": true,
-      "line": 3933,
+      "line": 3954,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "critical",
@@ -443,7 +471,7 @@
     {
       "name": "detectHeaderRow",
       "isAsync": false,
-      "line": 6337,
+      "line": 6528,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -457,7 +485,7 @@
     {
       "name": "detectNumericCandidateColumns",
       "isAsync": false,
-      "line": 6369,
+      "line": 6560,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -471,7 +499,7 @@
     {
       "name": "editCustomer",
       "isAsync": true,
-      "line": 4949,
+      "line": 4970,
       "scriptIndex": 0,
       "group": "users",
       "monitorLevel": "warning",
@@ -485,7 +513,7 @@
     {
       "name": "editProduct",
       "isAsync": false,
-      "line": 3894,
+      "line": 3915,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -499,7 +527,7 @@
     {
       "name": "editSupplier",
       "isAsync": false,
-      "line": 4076,
+      "line": 4097,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -513,7 +541,7 @@
     {
       "name": "enqueuePendingProductOp",
       "isAsync": false,
-      "line": 2470,
+      "line": 2484,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -527,7 +555,7 @@
     {
       "name": "ensureProductsSchema",
       "isAsync": false,
-      "line": 2410,
+      "line": 2424,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -541,7 +569,7 @@
     {
       "name": "ensureSuppliersSchema",
       "isAsync": false,
-      "line": 2416,
+      "line": 2430,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -555,7 +583,7 @@
     {
       "name": "escapeHtml",
       "isAsync": false,
-      "line": 5672,
+      "line": 5742,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -569,7 +597,7 @@
     {
       "name": "exportAllDataJSON",
       "isAsync": false,
-      "line": 7020,
+      "line": 7211,
       "scriptIndex": 0,
       "group": "reports",
       "monitorLevel": "info",
@@ -583,7 +611,7 @@
     {
       "name": "exportClientErrorsExcel",
       "isAsync": false,
-      "line": 5742,
+      "line": 5812,
       "scriptIndex": 0,
       "group": "reports",
       "monitorLevel": "info",
@@ -597,7 +625,7 @@
     {
       "name": "exportCouponsExcel",
       "isAsync": false,
-      "line": 6141,
+      "line": 6332,
       "scriptIndex": 0,
       "group": "coupons",
       "monitorLevel": "warning",
@@ -611,7 +639,7 @@
     {
       "name": "exportFullReport",
       "isAsync": false,
-      "line": 6146,
+      "line": 6337,
       "scriptIndex": 0,
       "group": "reports",
       "monitorLevel": "info",
@@ -625,7 +653,7 @@
     {
       "name": "exportOrdersExcel",
       "isAsync": false,
-      "line": 6131,
+      "line": 6322,
       "scriptIndex": 0,
       "group": "orders",
       "monitorLevel": "warning",
@@ -639,7 +667,7 @@
     {
       "name": "exportProductsExcel",
       "isAsync": false,
-      "line": 6108,
+      "line": 6299,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -653,7 +681,7 @@
     {
       "name": "exportToExcel",
       "isAsync": false,
-      "line": 6165,
+      "line": 6356,
       "scriptIndex": 0,
       "group": "reports",
       "monitorLevel": "info",
@@ -667,7 +695,7 @@
     {
       "name": "exportUsersExcel",
       "isAsync": false,
-      "line": 6136,
+      "line": 6327,
       "scriptIndex": 0,
       "group": "users",
       "monitorLevel": "warning",
@@ -681,7 +709,7 @@
     {
       "name": "flushPendingProductOps",
       "isAsync": true,
-      "line": 2538,
+      "line": 2552,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -695,7 +723,7 @@
     {
       "name": "formatDate",
       "isAsync": false,
-      "line": 4448,
+      "line": 4469,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -709,7 +737,7 @@
     {
       "name": "formatDateTime",
       "isAsync": false,
-      "line": 4453,
+      "line": 4474,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -723,7 +751,7 @@
     {
       "name": "getAdminFunctionGroupLabel",
       "isAsync": false,
-      "line": 5907,
+      "line": 6080,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -737,7 +765,7 @@
     {
       "name": "getAdminFunctionLevelLabel",
       "isAsync": false,
-      "line": 5900,
+      "line": 6073,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -751,7 +779,7 @@
     {
       "name": "getAdminFunctionStatusClass",
       "isAsync": false,
-      "line": 5939,
+      "line": 6112,
       "scriptIndex": 0,
       "group": "orders",
       "monitorLevel": "warning",
@@ -765,7 +793,7 @@
     {
       "name": "getAllCategoryDefinitions",
       "isAsync": false,
-      "line": 3326,
+      "line": 3347,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -779,7 +807,7 @@
     {
       "name": "getBestSheetForImport",
       "isAsync": false,
-      "line": 6488,
+      "line": 6679,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -793,7 +821,7 @@
     {
       "name": "getCategoryName",
       "isAsync": false,
-      "line": 3385,
+      "line": 3406,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -807,7 +835,7 @@
     {
       "name": "getCurrentSheetAnalysis",
       "isAsync": false,
-      "line": 6445,
+      "line": 6636,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -821,7 +849,7 @@
     {
       "name": "getDefaultCategoryDefinitions",
       "isAsync": false,
-      "line": 3310,
+      "line": 3331,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -835,7 +863,7 @@
     {
       "name": "getDeviceLabel",
       "isAsync": false,
-      "line": 5684,
+      "line": 5754,
       "scriptIndex": 0,
       "group": "reports",
       "monitorLevel": "info",
@@ -849,7 +877,7 @@
     {
       "name": "getImpactLabel",
       "isAsync": false,
-      "line": 5924,
+      "line": 6097,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -863,7 +891,7 @@
     {
       "name": "getMappedValue",
       "isAsync": false,
-      "line": 6712,
+      "line": 6903,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -877,7 +905,21 @@
     {
       "name": "getPendingOpEffectiveId",
       "isAsync": false,
-      "line": 2445,
+      "line": 2459,
+      "scriptIndex": 0,
+      "group": "utility",
+      "monitorLevel": "info",
+      "storeImpact": "none",
+      "mobileImpact": "none",
+      "persistenceMode": "memory_only",
+      "status": "ok",
+      "reasonCode": "BASELINE_OK",
+      "reasonText": "تم تسجيل الدالة ضمن المتابعة."
+    },
+    {
+      "name": "getPermissionErrorCode",
+      "isAsync": false,
+      "line": 5036,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -891,7 +933,7 @@
     {
       "name": "getPersistenceLabel",
       "isAsync": false,
-      "line": 5931,
+      "line": 6104,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -905,7 +947,7 @@
     {
       "name": "getSamplePurgeTargets",
       "isAsync": false,
-      "line": 7211,
+      "line": 7402,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -919,7 +961,7 @@
     {
       "name": "getStatusName",
       "isAsync": false,
-      "line": 4443,
+      "line": 4464,
       "scriptIndex": 0,
       "group": "orders",
       "monitorLevel": "warning",
@@ -933,7 +975,7 @@
     {
       "name": "getSupplierById",
       "isAsync": false,
-      "line": 3390,
+      "line": 3411,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -947,7 +989,7 @@
     {
       "name": "getSupportAccessErrorCode",
       "isAsync": false,
-      "line": 5015,
+      "line": 5072,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -961,7 +1003,7 @@
     {
       "name": "getSupportThreadById",
       "isAsync": false,
-      "line": 5101,
+      "line": 5149,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -975,7 +1017,7 @@
     {
       "name": "getSupportThreadStatusClass",
       "isAsync": false,
-      "line": 5110,
+      "line": 5158,
       "scriptIndex": 0,
       "group": "orders",
       "monitorLevel": "warning",
@@ -989,7 +1031,7 @@
     {
       "name": "getSupportThreadStatusLabel",
       "isAsync": false,
-      "line": 5106,
+      "line": 5154,
       "scriptIndex": 0,
       "group": "orders",
       "monitorLevel": "warning",
@@ -1003,7 +1045,7 @@
     {
       "name": "getUserDisplayName",
       "isAsync": false,
-      "line": 4839,
+      "line": 4860,
       "scriptIndex": 0,
       "group": "users",
       "monitorLevel": "warning",
@@ -1017,7 +1059,7 @@
     {
       "name": "handleLogin",
       "isAsync": true,
-      "line": 2864,
+      "line": 2878,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -1031,7 +1073,7 @@
     {
       "name": "handlePointsAction",
       "isAsync": true,
-      "line": 5549,
+      "line": 5619,
       "scriptIndex": 0,
       "group": "loyalty",
       "monitorLevel": "warning",
@@ -1045,7 +1087,7 @@
     {
       "name": "handleProductSupplierChange",
       "isAsync": false,
-      "line": 3440,
+      "line": 3461,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1057,9 +1099,23 @@
       "reasonText": "تم تسجيل الدالة ضمن المتابعة."
     },
     {
+      "name": "handleStoreOpsAccessError",
+      "isAsync": false,
+      "line": 5887,
+      "scriptIndex": 0,
+      "group": "utility",
+      "monitorLevel": "info",
+      "storeImpact": "none",
+      "mobileImpact": "none",
+      "persistenceMode": "memory_only",
+      "status": "ok",
+      "reasonCode": "BASELINE_OK",
+      "reasonText": "تم تسجيل الدالة ضمن المتابعة."
+    },
+    {
       "name": "handleSupportAccessError",
       "isAsync": false,
-      "line": 5064,
+      "line": 5112,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -1073,7 +1129,7 @@
     {
       "name": "hasAdminClaimFromTokenResult",
       "isAsync": false,
-      "line": 2850,
+      "line": 2864,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -1087,7 +1143,7 @@
     {
       "name": "importAllDataJSON",
       "isAsync": false,
-      "line": 7030,
+      "line": 7221,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1101,7 +1157,7 @@
     {
       "name": "importProductsExcel",
       "isAsync": false,
-      "line": 7012,
+      "line": 7203,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1115,7 +1171,7 @@
     {
       "name": "inferCategory",
       "isAsync": false,
-      "line": 2307,
+      "line": 2321,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1129,7 +1185,7 @@
     {
       "name": "initCharts",
       "isAsync": false,
-      "line": 7084,
+      "line": 7275,
       "scriptIndex": 0,
       "group": "reports",
       "monitorLevel": "info",
@@ -1143,7 +1199,7 @@
     {
       "name": "initDashboard",
       "isAsync": false,
-      "line": 3063,
+      "line": 3077,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -1157,7 +1213,21 @@
     {
       "name": "isExternalImageUrl",
       "isAsync": false,
-      "line": 3239,
+      "line": 3260,
+      "scriptIndex": 0,
+      "group": "utility",
+      "monitorLevel": "info",
+      "storeImpact": "none",
+      "mobileImpact": "none",
+      "persistenceMode": "memory_only",
+      "status": "ok",
+      "reasonCode": "BASELINE_OK",
+      "reasonText": "تم تسجيل الدالة ضمن المتابعة."
+    },
+    {
+      "name": "isPermissionDenied",
+      "isAsync": false,
+      "line": 5042,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -1171,7 +1241,7 @@
     {
       "name": "isSupportPermissionDenied",
       "isAsync": false,
-      "line": 5021,
+      "line": 5076,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -1185,7 +1255,7 @@
     {
       "name": "levelClass",
       "isAsync": false,
-      "line": 5762,
+      "line": 5832,
       "scriptIndex": 0,
       "group": "reports",
       "monitorLevel": "info",
@@ -1199,7 +1269,7 @@
     {
       "name": "loadAllData",
       "isAsync": true,
-      "line": 2696,
+      "line": 2710,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -1213,7 +1283,7 @@
     {
       "name": "loadCustomersPage",
       "isAsync": true,
-      "line": 4876,
+      "line": 4897,
       "scriptIndex": 0,
       "group": "users",
       "monitorLevel": "warning",
@@ -1227,7 +1297,7 @@
     {
       "name": "loadOrdersPage",
       "isAsync": true,
-      "line": 4360,
+      "line": 4381,
       "scriptIndex": 0,
       "group": "orders",
       "monitorLevel": "warning",
@@ -1241,7 +1311,7 @@
     {
       "name": "loadPendingProductOps",
       "isAsync": false,
-      "line": 2432,
+      "line": 2446,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1255,7 +1325,7 @@
     {
       "name": "loadProductFilterView",
       "isAsync": false,
-      "line": 3216,
+      "line": 3237,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1269,7 +1339,7 @@
     {
       "name": "loadSettingsToForms",
       "isAsync": false,
-      "line": 5576,
+      "line": 5646,
       "scriptIndex": 0,
       "group": "settings",
       "monitorLevel": "warning",
@@ -1283,7 +1353,21 @@
     {
       "name": "logAdmin",
       "isAsync": false,
-      "line": 2827,
+      "line": 2841,
+      "scriptIndex": 0,
+      "group": "utility",
+      "monitorLevel": "info",
+      "storeImpact": "none",
+      "mobileImpact": "none",
+      "persistenceMode": "memory_only",
+      "status": "ok",
+      "reasonCode": "BASELINE_OK",
+      "reasonText": "تم تسجيل الدالة ضمن المتابعة."
+    },
+    {
+      "name": "logWarnOnce",
+      "isAsync": false,
+      "line": 5053,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -1297,7 +1381,7 @@
     {
       "name": "makeImportBatchId",
       "isAsync": false,
-      "line": 2327,
+      "line": 2341,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1311,7 +1395,7 @@
     {
       "name": "markManualSellPriceOverride",
       "isAsync": false,
-      "line": 3433,
+      "line": 3454,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -1325,7 +1409,7 @@
     {
       "name": "nextImportWizardStep",
       "isAsync": false,
-      "line": 6821,
+      "line": 7012,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1339,7 +1423,7 @@
     {
       "name": "normalizeArabicHeader",
       "isAsync": false,
-      "line": 2294,
+      "line": 2308,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -1353,7 +1437,7 @@
     {
       "name": "normalizeProductForStorage",
       "isAsync": false,
-      "line": 2375,
+      "line": 2389,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1367,7 +1451,7 @@
     {
       "name": "openAddCategoryPrompt",
       "isAsync": false,
-      "line": 3354,
+      "line": 3375,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1381,7 +1465,7 @@
     {
       "name": "openImportWizard",
       "isAsync": false,
-      "line": 6245,
+      "line": 6436,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1395,7 +1479,7 @@
     {
       "name": "openModal",
       "isAsync": false,
-      "line": 7168,
+      "line": 7359,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -1409,7 +1493,7 @@
     {
       "name": "openProductModal",
       "isAsync": false,
-      "line": 7169,
+      "line": 7360,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1423,7 +1507,7 @@
     {
       "name": "openSupplierModal",
       "isAsync": false,
-      "line": 4059,
+      "line": 4080,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1437,7 +1521,7 @@
     {
       "name": "parseMoney",
       "isAsync": false,
-      "line": 2318,
+      "line": 2332,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -1451,7 +1535,7 @@
     {
       "name": "parseStockValue",
       "isAsync": false,
-      "line": 6720,
+      "line": 6911,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -1465,7 +1549,7 @@
     {
       "name": "parseWorkbook",
       "isAsync": true,
-      "line": 6640,
+      "line": 6831,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -1479,7 +1563,7 @@
     {
       "name": "patchPendingAddByTempId",
       "isAsync": false,
-      "line": 2452,
+      "line": 2466,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -1493,7 +1577,7 @@
     {
       "name": "persistPendingProductOps",
       "isAsync": false,
-      "line": 2441,
+      "line": 2455,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1507,7 +1591,7 @@
     {
       "name": "prevImportWizardStep",
       "isAsync": false,
-      "line": 6866,
+      "line": 7057,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1521,7 +1605,7 @@
     {
       "name": "printOrder",
       "isAsync": false,
-      "line": 4575,
+      "line": 4596,
       "scriptIndex": 0,
       "group": "orders",
       "monitorLevel": "warning",
@@ -1535,7 +1619,7 @@
     {
       "name": "publishBatchPrompt",
       "isAsync": true,
-      "line": 3663,
+      "line": 3684,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1549,7 +1633,7 @@
     {
       "name": "purgeSampleData",
       "isAsync": true,
-      "line": 7245,
+      "line": 7436,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -1563,7 +1647,7 @@
     {
       "name": "quickAddPoints",
       "isAsync": true,
-      "line": 5505,
+      "line": 5575,
       "scriptIndex": 0,
       "group": "loyalty",
       "monitorLevel": "warning",
@@ -1577,7 +1661,7 @@
     {
       "name": "quickSubPoints",
       "isAsync": true,
-      "line": 5527,
+      "line": 5597,
       "scriptIndex": 0,
       "group": "loyalty",
       "monitorLevel": "warning",
@@ -1591,7 +1675,7 @@
     {
       "name": "readWizardMappingFromUI",
       "isAsync": false,
-      "line": 6695,
+      "line": 6886,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1605,7 +1689,7 @@
     {
       "name": "recalculateProductPricingFromForm",
       "isAsync": false,
-      "line": 3407,
+      "line": 3428,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1619,7 +1703,7 @@
     {
       "name": "recalculateSupplierPrompt",
       "isAsync": true,
-      "line": 4259,
+      "line": 4280,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1633,7 +1717,7 @@
     {
       "name": "refreshAdminFunctionMonitorView",
       "isAsync": true,
-      "line": 6067,
+      "line": 6258,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -1647,7 +1731,7 @@
     {
       "name": "refreshClientErrorLogs",
       "isAsync": true,
-      "line": 5721,
+      "line": 5791,
       "scriptIndex": 0,
       "group": "reports",
       "monitorLevel": "info",
@@ -1661,7 +1745,7 @@
     {
       "name": "refreshStoreOperationsNow",
       "isAsync": true,
-      "line": 5882,
+      "line": 6047,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -1675,7 +1759,7 @@
     {
       "name": "refreshSupportThreads",
       "isAsync": true,
-      "line": 5300,
+      "line": 5353,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -1689,7 +1773,7 @@
     {
       "name": "removeQueuedOpsForProduct",
       "isAsync": false,
-      "line": 3538,
+      "line": 3559,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1703,7 +1787,7 @@
     {
       "name": "renderAdminFunctionSummary",
       "isAsync": false,
-      "line": 5976,
+      "line": 6149,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -1717,7 +1801,7 @@
     {
       "name": "renderAdminFunctionTable",
       "isAsync": false,
-      "line": 6008,
+      "line": 6199,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -1731,7 +1815,7 @@
     {
       "name": "renderAdminSupplierFilterOptions",
       "isAsync": false,
-      "line": 3191,
+      "line": 3212,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1745,7 +1829,7 @@
     {
       "name": "renderBannersTable",
       "isAsync": false,
-      "line": 4630,
+      "line": 4651,
       "scriptIndex": 0,
       "group": "banners",
       "monitorLevel": "warning",
@@ -1759,7 +1843,7 @@
     {
       "name": "renderClientErrorLogsTable",
       "isAsync": false,
-      "line": 5692,
+      "line": 5762,
       "scriptIndex": 0,
       "group": "reports",
       "monitorLevel": "info",
@@ -1773,7 +1857,7 @@
     {
       "name": "renderCouponsTable",
       "isAsync": false,
-      "line": 4719,
+      "line": 4740,
       "scriptIndex": 0,
       "group": "coupons",
       "monitorLevel": "warning",
@@ -1787,7 +1871,7 @@
     {
       "name": "renderLiveSessionsTable",
       "isAsync": false,
-      "line": 5809,
+      "line": 5953,
       "scriptIndex": 0,
       "group": "reports",
       "monitorLevel": "info",
@@ -1801,7 +1885,7 @@
     {
       "name": "renderLoyaltySection",
       "isAsync": false,
-      "line": 5449,
+      "line": 5519,
       "scriptIndex": 0,
       "group": "loyalty",
       "monitorLevel": "warning",
@@ -1815,7 +1899,7 @@
     {
       "name": "renderOrdersTable",
       "isAsync": false,
-      "line": 4323,
+      "line": 4344,
       "scriptIndex": 0,
       "group": "orders",
       "monitorLevel": "warning",
@@ -1829,7 +1913,7 @@
     {
       "name": "renderProductCategoryOptions",
       "isAsync": false,
-      "line": 3339,
+      "line": 3360,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1843,7 +1927,7 @@
     {
       "name": "renderProductsTable",
       "isAsync": false,
-      "line": 3130,
+      "line": 3151,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1857,7 +1941,7 @@
     {
       "name": "renderRecentOrders",
       "isAsync": false,
-      "line": 4417,
+      "line": 4438,
       "scriptIndex": 0,
       "group": "orders",
       "monitorLevel": "warning",
@@ -1871,7 +1955,7 @@
     {
       "name": "renderStoreEventsTable",
       "isAsync": false,
-      "line": 5779,
+      "line": 5923,
       "scriptIndex": 0,
       "group": "reports",
       "monitorLevel": "info",
@@ -1885,7 +1969,7 @@
     {
       "name": "renderSupplierOptions",
       "isAsync": false,
-      "line": 3396,
+      "line": 3417,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1899,7 +1983,7 @@
     {
       "name": "renderSuppliersTable",
       "isAsync": false,
-      "line": 4025,
+      "line": 4046,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1913,7 +1997,7 @@
     {
       "name": "renderSupportMessages",
       "isAsync": false,
-      "line": 5169,
+      "line": 5217,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -1927,7 +2011,7 @@
     {
       "name": "renderSupportThreads",
       "isAsync": false,
-      "line": 5118,
+      "line": 5166,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -1941,7 +2025,7 @@
     {
       "name": "renderUsersTable",
       "isAsync": false,
-      "line": 4845,
+      "line": 4866,
       "scriptIndex": 0,
       "group": "users",
       "monitorLevel": "warning",
@@ -1955,7 +2039,7 @@
     {
       "name": "renderWizardFileValidationReport",
       "isAsync": false,
-      "line": 6453,
+      "line": 6644,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1969,7 +2053,7 @@
     {
       "name": "renderWizardTable",
       "isAsync": false,
-      "line": 6277,
+      "line": 6468,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1983,7 +2067,7 @@
     {
       "name": "renderWizardValidationReport",
       "isAsync": false,
-      "line": 6726,
+      "line": 6917,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -1997,7 +2081,7 @@
     {
       "name": "requireAdminPermission",
       "isAsync": true,
-      "line": 2854,
+      "line": 2868,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -2011,7 +2095,7 @@
     {
       "name": "resetCustomerPassword",
       "isAsync": true,
-      "line": 5008,
+      "line": 5029,
       "scriptIndex": 0,
       "group": "users",
       "monitorLevel": "warning",
@@ -2025,7 +2109,7 @@
     {
       "name": "resetImportWizardState",
       "isAsync": false,
-      "line": 6210,
+      "line": 6401,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -2039,7 +2123,7 @@
     {
       "name": "resetProductForm",
       "isAsync": false,
-      "line": 3970,
+      "line": 3991,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -2053,7 +2137,7 @@
     {
       "name": "resetSupplierForm",
       "isAsync": false,
-      "line": 4064,
+      "line": 4085,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -2067,7 +2151,7 @@
     {
       "name": "resolveAutoMapping",
       "isAsync": false,
-      "line": 6554,
+      "line": 6745,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -2081,7 +2165,7 @@
     {
       "name": "resolveProductPricingFields",
       "isAsync": false,
-      "line": 2331,
+      "line": 2345,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -2095,7 +2179,7 @@
     {
       "name": "runPreflightCheck",
       "isAsync": true,
-      "line": 7396,
+      "line": 7587,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -2109,7 +2193,7 @@
     {
       "name": "runProductsSchemaMigration",
       "isAsync": true,
-      "line": 7318,
+      "line": 7509,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -2123,7 +2207,7 @@
     {
       "name": "safeJsonPreview",
       "isAsync": false,
-      "line": 5769,
+      "line": 5839,
       "scriptIndex": 0,
       "group": "reports",
       "monitorLevel": "info",
@@ -2137,7 +2221,7 @@
     {
       "name": "safeSupportTime",
       "isAsync": false,
-      "line": 5114,
+      "line": 5162,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -2151,7 +2235,7 @@
     {
       "name": "sanitizeAdminFunctionEntry",
       "isAsync": false,
-      "line": 5946,
+      "line": 6119,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -2165,7 +2249,7 @@
     {
       "name": "sanitizeAllImages",
       "isAsync": true,
-      "line": 3252,
+      "line": 3273,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -2179,7 +2263,7 @@
     {
       "name": "sanitizeCategoryId",
       "isAsync": false,
-      "line": 3320,
+      "line": 3341,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -2193,7 +2277,7 @@
     {
       "name": "sanitizeImageUrl",
       "isAsync": false,
-      "line": 3110,
+      "line": 3131,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -2207,7 +2291,7 @@
     {
       "name": "saveAdminPassword",
       "isAsync": false,
-      "line": 2826,
+      "line": 2840,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -2221,7 +2305,7 @@
     {
       "name": "saveBanner",
       "isAsync": true,
-      "line": 4654,
+      "line": 4675,
       "scriptIndex": 0,
       "group": "banners",
       "monitorLevel": "critical",
@@ -2235,7 +2319,7 @@
     {
       "name": "saveBanners",
       "isAsync": false,
-      "line": 2823,
+      "line": 2837,
       "scriptIndex": 0,
       "group": "banners",
       "monitorLevel": "warning",
@@ -2249,7 +2333,7 @@
     {
       "name": "saveContactSettings",
       "isAsync": false,
-      "line": 5650,
+      "line": 5720,
       "scriptIndex": 0,
       "group": "settings",
       "monitorLevel": "critical",
@@ -2263,7 +2347,7 @@
     {
       "name": "saveCoupon",
       "isAsync": true,
-      "line": 4744,
+      "line": 4765,
       "scriptIndex": 0,
       "group": "coupons",
       "monitorLevel": "critical",
@@ -2277,7 +2361,7 @@
     {
       "name": "saveCoupons",
       "isAsync": false,
-      "line": 2822,
+      "line": 2836,
       "scriptIndex": 0,
       "group": "coupons",
       "monitorLevel": "warning",
@@ -2291,7 +2375,7 @@
     {
       "name": "saveFooterSettings",
       "isAsync": false,
-      "line": 5637,
+      "line": 5707,
       "scriptIndex": 0,
       "group": "settings",
       "monitorLevel": "critical",
@@ -2305,7 +2389,7 @@
     {
       "name": "saveGeneralSettings",
       "isAsync": false,
-      "line": 5599,
+      "line": 5669,
       "scriptIndex": 0,
       "group": "settings",
       "monitorLevel": "critical",
@@ -2319,7 +2403,7 @@
     {
       "name": "saveLoyaltySettings",
       "isAsync": false,
-      "line": 5494,
+      "line": 5564,
       "scriptIndex": 0,
       "group": "loyalty",
       "monitorLevel": "warning",
@@ -2333,7 +2417,7 @@
     {
       "name": "saveOrders",
       "isAsync": false,
-      "line": 2817,
+      "line": 2831,
       "scriptIndex": 0,
       "group": "orders",
       "monitorLevel": "warning",
@@ -2347,7 +2431,7 @@
     {
       "name": "saveProduct",
       "isAsync": true,
-      "line": 3777,
+      "line": 3798,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "critical",
@@ -2361,7 +2445,7 @@
     {
       "name": "saveProductFilterView",
       "isAsync": false,
-      "line": 3202,
+      "line": 3223,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -2375,7 +2459,7 @@
     {
       "name": "saveProducts",
       "isAsync": false,
-      "line": 2798,
+      "line": 2812,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -2389,7 +2473,7 @@
     {
       "name": "saveStoreSettings",
       "isAsync": false,
-      "line": 2838,
+      "line": 2852,
       "scriptIndex": 0,
       "group": "settings",
       "monitorLevel": "critical",
@@ -2403,7 +2487,7 @@
     {
       "name": "saveSupplier",
       "isAsync": true,
-      "line": 4092,
+      "line": 4113,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "critical",
@@ -2417,7 +2501,7 @@
     {
       "name": "saveSuppliers",
       "isAsync": false,
-      "line": 2825,
+      "line": 2839,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -2431,7 +2515,7 @@
     {
       "name": "saveTopBarSettings",
       "isAsync": false,
-      "line": 5625,
+      "line": 5695,
       "scriptIndex": 0,
       "group": "settings",
       "monitorLevel": "critical",
@@ -2445,7 +2529,7 @@
     {
       "name": "saveUsers",
       "isAsync": false,
-      "line": 2824,
+      "line": 2838,
       "scriptIndex": 0,
       "group": "users",
       "monitorLevel": "warning",
@@ -2459,7 +2543,7 @@
     {
       "name": "scoreHeaderCell",
       "isAsync": false,
-      "line": 6317,
+      "line": 6508,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -2473,7 +2557,7 @@
     {
       "name": "selectImportSheet",
       "isAsync": false,
-      "line": 6511,
+      "line": 6702,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -2487,7 +2571,7 @@
     {
       "name": "selectSupportThread",
       "isAsync": true,
-      "line": 5249,
+      "line": 5297,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -2501,7 +2585,7 @@
     {
       "name": "sendPasswordReset",
       "isAsync": true,
-      "line": 2972,
+      "line": 2986,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -2515,7 +2599,7 @@
     {
       "name": "sendSupportReply",
       "isAsync": true,
-      "line": 5378,
+      "line": 5442,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -2529,7 +2613,7 @@
     {
       "name": "sendVerificationLink",
       "isAsync": true,
-      "line": 2944,
+      "line": 2958,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -2543,7 +2627,7 @@
     {
       "name": "sendWhatsAppUpdate",
       "isAsync": false,
-      "line": 4567,
+      "line": 4588,
       "scriptIndex": 0,
       "group": "orders",
       "monitorLevel": "warning",
@@ -2557,7 +2641,7 @@
     {
       "name": "setAllProductsVisibility",
       "isAsync": true,
-      "line": 3678,
+      "line": 3699,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "critical",
@@ -2571,7 +2655,7 @@
     {
       "name": "setHeaderRowManual",
       "isAsync": false,
-      "line": 6599,
+      "line": 6790,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -2585,7 +2669,7 @@
     {
       "name": "setWizardProgress",
       "isAsync": false,
-      "line": 6202,
+      "line": 6393,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -2599,7 +2683,7 @@
     {
       "name": "setupAutoTooltips",
       "isAsync": false,
-      "line": 7160,
+      "line": 7351,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -2613,7 +2697,7 @@
     {
       "name": "setupServiceWorkerAutoUpdate",
       "isAsync": false,
-      "line": 2601,
+      "line": 2615,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -2627,7 +2711,7 @@
     {
       "name": "showImportWizardStep",
       "isAsync": false,
-      "line": 6250,
+      "line": 6441,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -2641,7 +2725,7 @@
     {
       "name": "showNotification",
       "isAsync": false,
-      "line": 7189,
+      "line": 7380,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -2655,7 +2739,7 @@
     {
       "name": "showSection",
       "isAsync": false,
-      "line": 7115,
+      "line": 7306,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -2669,7 +2753,7 @@
     {
       "name": "startCustomersRealtimeSync",
       "isAsync": false,
-      "line": 4941,
+      "line": 4962,
       "scriptIndex": 0,
       "group": "users",
       "monitorLevel": "warning",
@@ -2682,8 +2766,8 @@
     },
     {
       "name": "startStoreOperationsMonitoring",
-      "isAsync": false,
-      "line": 5856,
+      "isAsync": true,
+      "line": 6001,
       "scriptIndex": 0,
       "group": "reports",
       "monitorLevel": "info",
@@ -2697,7 +2781,7 @@
     {
       "name": "startSupportChatRealtime",
       "isAsync": true,
-      "line": 5323,
+      "line": 5379,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -2711,7 +2795,7 @@
     {
       "name": "stopCustomersRealtimeSync",
       "isAsync": false,
-      "line": 4945,
+      "line": 4966,
       "scriptIndex": 0,
       "group": "users",
       "monitorLevel": "warning",
@@ -2725,7 +2809,7 @@
     {
       "name": "stopStoreOperationsMonitoring",
       "isAsync": false,
-      "line": 5849,
+      "line": 5993,
       "scriptIndex": 0,
       "group": "reports",
       "monitorLevel": "info",
@@ -2739,7 +2823,7 @@
     {
       "name": "stopSupportChatRealtime",
       "isAsync": false,
-      "line": 5370,
+      "line": 5434,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -2753,7 +2837,7 @@
     {
       "name": "switchTab",
       "isAsync": false,
-      "line": 5662,
+      "line": 5732,
       "scriptIndex": 0,
       "group": "settings",
       "monitorLevel": "warning",
@@ -2767,7 +2851,7 @@
     {
       "name": "syncCustomersFromFirebaseNow",
       "isAsync": true,
-      "line": 4932,
+      "line": 4953,
       "scriptIndex": 0,
       "group": "users",
       "monitorLevel": "warning",
@@ -2781,7 +2865,7 @@
     {
       "name": "toggleProductPublish",
       "isAsync": true,
-      "line": 3549,
+      "line": 3570,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -2795,7 +2879,7 @@
     {
       "name": "toggleSidebar",
       "isAsync": false,
-      "line": 7137,
+      "line": 7328,
       "scriptIndex": 0,
       "group": "system",
       "monitorLevel": "info",
@@ -2809,7 +2893,7 @@
     {
       "name": "toggleSupplierArchive",
       "isAsync": true,
-      "line": 4167,
+      "line": 4188,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "critical",
@@ -2823,7 +2907,7 @@
     {
       "name": "updateBadges",
       "isAsync": false,
-      "line": 3095,
+      "line": 3116,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -2837,7 +2921,7 @@
     {
       "name": "updateBatchVisibility",
       "isAsync": true,
-      "line": 3597,
+      "line": 3618,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -2851,7 +2935,7 @@
     {
       "name": "updateOrderStatus",
       "isAsync": true,
-      "line": 4538,
+      "line": 4559,
       "scriptIndex": 0,
       "group": "orders",
       "monitorLevel": "critical",
@@ -2865,7 +2949,7 @@
     {
       "name": "updateOrdersPaginationUi",
       "isAsync": false,
-      "line": 4307,
+      "line": 4328,
       "scriptIndex": 0,
       "group": "orders",
       "monitorLevel": "warning",
@@ -2879,7 +2963,21 @@
     {
       "name": "updateStats",
       "isAsync": false,
-      "line": 3087,
+      "line": 3108,
+      "scriptIndex": 0,
+      "group": "utility",
+      "monitorLevel": "info",
+      "storeImpact": "none",
+      "mobileImpact": "none",
+      "persistenceMode": "memory_only",
+      "status": "ok",
+      "reasonCode": "BASELINE_OK",
+      "reasonText": "تم تسجيل الدالة ضمن المتابعة."
+    },
+    {
+      "name": "updateStoreOpsAccessUi",
+      "isAsync": false,
+      "line": 5849,
       "scriptIndex": 0,
       "group": "utility",
       "monitorLevel": "info",
@@ -2893,7 +2991,7 @@
     {
       "name": "updateSupportAccessUi",
       "isAsync": false,
-      "line": 5032,
+      "line": 5080,
       "scriptIndex": 0,
       "group": "support",
       "monitorLevel": "warning",
@@ -2907,7 +3005,7 @@
     {
       "name": "updateUsersPaginationUi",
       "isAsync": false,
-      "line": 4823,
+      "line": 4844,
       "scriptIndex": 0,
       "group": "users",
       "monitorLevel": "warning",
@@ -2921,7 +3019,7 @@
     {
       "name": "uploadAndPreview",
       "isAsync": true,
-      "line": 7458,
+      "line": 7649,
       "scriptIndex": 1,
       "group": "utility",
       "monitorLevel": "info",
@@ -2935,7 +3033,7 @@
     {
       "name": "validateImportRows",
       "isAsync": false,
-      "line": 6741,
+      "line": 6932,
       "scriptIndex": 0,
       "group": "products",
       "monitorLevel": "warning",
@@ -2949,7 +3047,7 @@
     {
       "name": "viewOrder",
       "isAsync": false,
-      "line": 4460,
+      "line": 4481,
       "scriptIndex": 0,
       "group": "orders",
       "monitorLevel": "warning",
@@ -2959,7 +3057,21 @@
       "status": "ok",
       "reasonCode": "BASELINE_OK",
       "reasonText": "تم تسجيل الدالة ضمن المتابعة."
+    },
+    {
+      "name": "warnPermissionDeniedOnce",
+      "isAsync": false,
+      "line": 5065,
+      "scriptIndex": 0,
+      "group": "utility",
+      "monitorLevel": "info",
+      "storeImpact": "none",
+      "mobileImpact": "none",
+      "persistenceMode": "memory_only",
+      "status": "ok",
+      "reasonCode": "BASELINE_OK",
+      "reasonText": "تم تسجيل الدالة ضمن المتابعة."
     }
   ],
-  "registryHash": "b7f4d4846134164cececbf0cd839f719e93a77d7c62bef72c16deee983fd7045"
+  "registryHash": "b47632c59eafcffac582cdbf8ecd9ce7111bb4cbfd162d961e1c6a11f9fea2b4"
 }

--- a/tools/admin-function-monitor.js
+++ b/tools/admin-function-monitor.js
@@ -80,6 +80,23 @@ function indexRowsByName(rows) {
   return map;
 }
 
+function countBy(rows, field, allowedValues) {
+  const summary = {};
+  const values = Array.isArray(allowedValues) ? allowedValues : [];
+  for (const value of values) {
+    summary[value] = 0;
+  }
+
+  for (const row of rows) {
+    const key = String(row && row[field] || '').toLowerCase();
+    if (Object.prototype.hasOwnProperty.call(summary, key)) {
+      summary[key] += 1;
+    }
+  }
+
+  return summary;
+}
+
 function runMonitor() {
   const nowIso = new Date().toISOString();
 
@@ -251,6 +268,9 @@ function runMonitor() {
     warningCount: rows.filter((row) => row.monitorLevel === 'warning').length,
     directStoreImpactCount: rows.filter((row) => row.storeImpact === 'direct').length,
     directMobileImpactCount: rows.filter((row) => row.mobileImpact === 'direct').length,
+    storeImpact: countBy(rows, 'storeImpact', ['direct', 'indirect', 'none']),
+    mobileImpact: countBy(rows, 'mobileImpact', ['direct', 'indirect', 'none']),
+    persistenceModes: countBy(rows, 'persistenceMode', ['firebase_online', 'hybrid', 'local_temporary', 'memory_only']),
     criticalFailures
   };
 

--- a/tools/e2e-check.js
+++ b/tools/e2e-check.js
@@ -138,6 +138,30 @@ requirePattern(
   /function\s+applyAdminFunctionFilters\s*\(/,
   'admin function monitor filters are missing'
 );
+requirePattern(
+  adminHtml,
+  'admin-store-ops-notice',
+  /id="storeOpsAccessNotice"/,
+  'store operations permission notice is missing'
+);
+requirePattern(
+  adminHtml,
+  'admin-store-ops-handler',
+  /function\s+handleStoreOpsAccessError\s*\(/,
+  'store operations permission handler is missing'
+);
+requirePattern(
+  adminHtml,
+  'admin-store-ops-guard',
+  /function\s+canUseStoreOps\s*\(/,
+  'store operations guard function is missing'
+);
+requirePattern(
+  adminHtml,
+  'admin-store-ops-require-admin',
+  /async\s+function\s+startStoreOperationsMonitoring\s*\([\s\S]*await\s+requireAdminPermission\(\)/,
+  'store operations realtime start must require admin permission first'
+);
 forbidPattern(
   adminHtml,
   'admin-monitor-sensitive-patterns',
@@ -149,6 +173,30 @@ forbidPattern(
   'admin-monitor-sensitive-regex-findings',
   /regexValidationFindings/,
   'admin monitor UI must not expose regex validation internals'
+);
+forbidPattern(
+  adminHtml,
+  'admin-noisy-store-events-console-error',
+  /console\.error\(\s*['"]store events listener error:/,
+  'store events listener should not spam console.error on permission denials'
+);
+forbidPattern(
+  adminHtml,
+  'admin-noisy-live-sessions-console-error',
+  /console\.error\(\s*['"]live sessions listener error:/,
+  'live sessions listener should not spam console.error on permission denials'
+);
+forbidPattern(
+  adminHtml,
+  'admin-noisy-support-messages-console-error',
+  /console\.error\(\s*['"]support messages listener error:/,
+  'support messages listener should not spam console.error on permission denials'
+);
+forbidPattern(
+  adminHtml,
+  'admin-noisy-support-threads-console-error',
+  /console\.error\(\s*['"]support threads listener error:/,
+  'support threads listener should not spam console.error on permission denials'
 );
 
 if (failures.length) {

--- a/tools/smoke-check.js
+++ b/tools/smoke-check.js
@@ -59,8 +59,18 @@ assertContains(adminHtml, /core\/logger\.js/, 'admin HTML: missing core/logger.j
 assertContains(adminHtml, /id="productCostPrice"/, 'admin HTML: missing product cost input', errors);
 assertContains(adminHtml, /function\s+runProductsSchemaMigration\s*\(/, 'admin HTML: missing schema migration action', errors);
 assertContains(adminHtml, /supportAccess\s*=\s*\{/, 'admin HTML: supportAccess state missing', errors);
+assertContains(adminHtml, /storeOpsAccess\s*=\s*\{/, 'admin HTML: storeOpsAccess state missing', errors);
 assertContains(adminHtml, /function\s+handleSupportAccessError\s*\(/, 'admin HTML: support access error handler missing', errors);
+assertContains(adminHtml, /function\s+handleStoreOpsAccessError\s*\(/, 'admin HTML: store operations access error handler missing', errors);
+assertContains(adminHtml, /function\s+canUseStoreOps\s*\(/, 'admin HTML: canUseStoreOps guard missing', errors);
 assertContains(adminHtml, /id="supportAccessNotice"/, 'admin HTML: support access notice missing', errors);
+assertContains(adminHtml, /id="storeOpsAccessNotice"/, 'admin HTML: store operations access notice missing', errors);
+assertContains(
+  adminHtml,
+  /async\s+function\s+startStoreOperationsMonitoring\s*\([\s\S]*await\s+requireAdminPermission\(\)[\s\S]*subscribeStoreEvents\(/,
+  'admin HTML: store operations must require admin permission before subscriptions',
+  errors
+);
 assertContains(adminHtml, /id="usersPaginationMeta"/, 'admin HTML: users pagination meta missing', errors);
 assertContains(adminHtml, /function\s+loadCustomersPage\s*\(/, 'admin HTML: loadCustomersPage() missing', errors);
 assertContains(adminHtml, /listCustomersPage\s*\(/, 'admin HTML: listCustomersPage() usage missing', errors);
@@ -83,6 +93,10 @@ assertNotContains(adminHtml, /window\.onerror\s*=/, 'admin HTML: direct window.o
 assertNotContains(adminHtml, /window\.onunhandledrejection\s*=/, 'admin HTML: direct window.onunhandledrejection assignment is not allowed', errors);
 assertNotContains(adminHtml, /requiredPatterns/, 'admin HTML: sensitive pattern internals must not be rendered in UI', errors);
 assertNotContains(adminHtml, /regexValidationFindings/, 'admin HTML: sensitive regex internals must not be rendered in UI', errors);
+assertNotContains(adminHtml, /console\.error\(\s*['"]store events listener error:/, 'admin HTML: noisy store events listener console.error should be removed', errors);
+assertNotContains(adminHtml, /console\.error\(\s*['"]live sessions listener error:/, 'admin HTML: noisy live sessions listener console.error should be removed', errors);
+assertNotContains(adminHtml, /console\.error\(\s*['"]support messages listener error:/, 'admin HTML: noisy support messages listener console.error should be removed', errors);
+assertNotContains(adminHtml, /console\.error\(\s*['"]support threads listener error:/, 'admin HTML: noisy support threads listener console.error should be removed', errors);
 
 assertContains(storeHtml, /product-search-worker\.js/, 'store HTML: missing worker reference path', errors);
 assertContains(storeHtml, /security-utils\.js/, 'store HTML: missing security-utils.js include', errors);

--- a/ادمن_2.HTML
+++ b/ادمن_2.HTML
@@ -1355,6 +1355,7 @@
                         </div>
                     </div>
                     <div class="section-body">
+                        <div id="storeOpsAccessNotice" style="display:none;margin-bottom:12px;padding:10px 12px;border-radius:10px;background:#fff4e5;color:#8a4b08;font-size:12px;font-weight:600;"></div>
                         <div class="stats-grid" style="margin-bottom: 14px;">
                             <div class="stat-card users">
                                 <div class="stat-icon">🟢</div>
@@ -1448,6 +1449,12 @@
 
                         <p id="adminFunctionsMeta" style="color: #666; margin-bottom: 12px; font-size: 13px;">
                             جارٍ تحميل سجل وظائف الأدمن...
+                        </p>
+                        <p id="adminFunctionsImpactSummary" style="color: #666; margin-bottom: 6px; font-size: 12px;">
+                            تأثير المتجر/الموبايل: جارٍ التحميل...
+                        </p>
+                        <p id="adminFunctionsPersistenceSummary" style="color: #666; margin-bottom: 12px; font-size: 12px;">
+                            نمط الحفظ: جارٍ التحميل...
                         </p>
 
                         <div class="form-row-3">
@@ -2245,8 +2252,15 @@
             source: '',
             notifiedReason: ''
         };
+        let storeOpsAccess = {
+            denied: false,
+            reason: '',
+            source: '',
+            notifiedReason: ''
+        };
         let storeEventsUnsubscribe = null;
         let liveSessionsUnsubscribe = null;
+        const warningLogOnce = new Set();
         // 🔐 تحسين الأمان: كلمة مرور قوية افتراضياً
         // ⚠️ يُنصح بتغييرها فوراً بعد أول تسجيل دخول
         let adminPassword = null;
@@ -3076,11 +3090,18 @@ function adminLogout(){
             renderClientErrorLogsTable();
             renderStoreEventsTable();
             renderLiveSessionsTable();
+            updateStoreOpsAccessUi();
             renderSupportThreads();
             renderSupportMessages();
             loadSettingsToForms();
             initCharts();
-            startStoreOperationsMonitoring();
+            startStoreOperationsMonitoring().catch((error) => {
+                logWarnOnce(
+                    'startStoreOperationsMonitoring.init.warning',
+                    'store operations init warning:',
+                    String(error && error.message ? error.message : error)
+                );
+            });
             startSupportChatRealtime();
         }
 
@@ -5012,21 +5033,48 @@ function adminLogout(){
         // ============================================
         // Internal Support Chat
         // ============================================
-        function getSupportAccessErrorCode(error) {
+        function getPermissionErrorCode(error) {
             const rawCode = String(error && (error.code || error.errorCode) || '').trim().toLowerCase();
             if (!rawCode) return '';
             return rawCode.startsWith('firebase/') ? rawCode.slice('firebase/'.length) : rawCode;
         }
 
-        function isSupportPermissionDenied(error) {
+        function isPermissionDenied(error) {
             if (!error) return false;
             if (error.permissionDenied === true) return true;
-            const code = getSupportAccessErrorCode(error);
+            const code = getPermissionErrorCode(error);
             if (code === 'permission-denied' || code === 'permission_denied') return true;
             const message = String(error && (error.message || error.reason) || error || '').toLowerCase();
             return message.includes('missing or insufficient permissions')
                 || message.includes('insufficient permissions')
                 || message.includes('permission-denied');
+        }
+
+        function logWarnOnce(key, message, meta) {
+            const normalizedKey = String(key || '').trim();
+            if (!normalizedKey) return;
+            if (warningLogOnce.has(normalizedKey)) return;
+            warningLogOnce.add(normalizedKey);
+            if (typeof meta === 'undefined') {
+                console.warn(message);
+            } else {
+                console.warn(message, meta);
+            }
+        }
+
+        function warnPermissionDeniedOnce(source, error, prefix = 'permission denied') {
+            const code = getPermissionErrorCode(error) || 'unknown';
+            const key = `${String(source || 'permission')}|${code}`;
+            const reason = String(error && (error.message || error.reason) || error || 'unknown permission error').trim();
+            logWarnOnce(key, `${prefix} (${String(source || 'unknown')}): ${reason}`);
+        }
+
+        function getSupportAccessErrorCode(error) {
+            return getPermissionErrorCode(error);
+        }
+
+        function isSupportPermissionDenied(error) {
+            return isPermissionDenied(error);
         }
 
         function updateSupportAccessUi() {
@@ -5076,7 +5124,7 @@ function adminLogout(){
                 showNotification('error', 'تعذر تشغيل الدردشة الداخلية بسبب الصلاحيات. باقي لوحة الأدمن تعمل بشكل طبيعي.');
             }
 
-            console.warn(`support access denied (${normalizedSource}):`, reason);
+            warnPermissionDeniedOnce(normalizedSource, error, 'support access denied');
             stopSupportChatRealtime();
             supportThreads = [];
             supportMessages = [];
@@ -5280,10 +5328,15 @@ function adminLogout(){
                         renderSupportThreads();
                     },
                     (error) => {
-                        console.error('support messages listener error:', error);
                         if (handleSupportAccessError(error, 'selectSupportThread.listener')) {
                             clearSupportMessageSubscription();
+                            return;
                         }
+                        logWarnOnce(
+                            'selectSupportThread.listener.warning',
+                            'support messages listener warning:',
+                            String(error && error.message ? error.message : error)
+                        );
                     },
                     300
                 );
@@ -5313,10 +5366,13 @@ function adminLogout(){
                 }
                 showNotification('success', 'تم تحديث المحادثات');
             } catch (error) {
-                console.error('refreshSupportThreads error:', error);
-                if (!handleSupportAccessError(error, 'refreshSupportThreads')) {
-                    showNotification('error', 'فشل تحديث المحادثات');
-                }
+                if (handleSupportAccessError(error, 'refreshSupportThreads')) return;
+                logWarnOnce(
+                    'refreshSupportThreads.warning',
+                    'refreshSupportThreads warning:',
+                    String(error && error.message ? error.message : error)
+                );
+                showNotification('error', 'فشل تحديث المحادثات');
             }
         }
 
@@ -5336,9 +5392,12 @@ function adminLogout(){
             try {
                 await requireAdminPermission();
             } catch (error) {
-                if (!handleSupportAccessError(error, 'startSupportChatRealtime.requireAdminPermission')) {
-                    console.error('support realtime admin permission error:', error);
-                }
+                if (handleSupportAccessError(error, 'startSupportChatRealtime.requireAdminPermission')) return;
+                logWarnOnce(
+                    'startSupportChatRealtime.requireAdminPermission.warning',
+                    'support realtime admin permission warning:',
+                    String(error && error.message ? error.message : error)
+                );
                 return;
             }
 
@@ -5358,10 +5417,15 @@ function adminLogout(){
                     }
                 },
                 (error) => {
-                    console.error('support threads listener error:', error);
                     if (handleSupportAccessError(error, 'startSupportChatRealtime.listener')) {
                         stopSupportChatRealtime();
+                        return;
                     }
+                    logWarnOnce(
+                        'startSupportChatRealtime.listener.warning',
+                        'support threads listener warning:',
+                        String(error && error.message ? error.message : error)
+                    );
                 },
                 250
             );
@@ -5407,10 +5471,13 @@ function adminLogout(){
                 });
                 input.value = '';
             } catch (error) {
-                console.error('sendSupportReply error:', error);
-                if (!handleSupportAccessError(error, 'sendSupportReply')) {
-                    showNotification('error', 'فشل إرسال الرد');
-                }
+                if (handleSupportAccessError(error, 'sendSupportReply')) return;
+                logWarnOnce(
+                    'sendSupportReply.warning',
+                    'sendSupportReply warning:',
+                    String(error && error.message ? error.message : error)
+                );
+                showNotification('error', 'فشل إرسال الرد');
             }
         }
 
@@ -5436,10 +5503,13 @@ function adminLogout(){
                 renderSupportMessages();
                 showNotification('success', 'تم إغلاق المحادثة');
             } catch (error) {
-                console.error('closeActiveSupportThread error:', error);
-                if (!handleSupportAccessError(error, 'closeActiveSupportThread')) {
-                    showNotification('error', 'فشل إغلاق المحادثة');
-                }
+                if (handleSupportAccessError(error, 'closeActiveSupportThread')) return;
+                logWarnOnce(
+                    'closeActiveSupportThread.warning',
+                    'closeActiveSupportThread warning:',
+                    String(error && error.message ? error.message : error)
+                );
+                showNotification('error', 'فشل إغلاق المحادثة');
             }
         }
 
@@ -5776,6 +5846,80 @@ function adminLogout(){
             }
         }
 
+        function updateStoreOpsAccessUi() {
+            const noticeEl = document.getElementById('storeOpsAccessNotice');
+            const liveBadge = document.getElementById('storeOpsLiveBadge');
+
+            if (noticeEl) {
+                if (storeOpsAccess.denied) {
+                    const source = String(storeOpsAccess.source || 'store-ops');
+                    noticeEl.textContent = `تعذر تشغيل المراقبة اللحظية بسبب الصلاحيات (source: ${source}). باقي لوحة الأدمن تعمل طبيعي.`;
+                    noticeEl.style.display = 'block';
+                } else {
+                    noticeEl.style.display = 'none';
+                    noticeEl.textContent = '';
+                }
+            }
+
+            if (!liveBadge) return;
+            if (storeOpsAccess.denied) {
+                liveBadge.textContent = 'LOCKED';
+                liveBadge.className = 'status-badge status-cancelled';
+                return;
+            }
+            if (storeEventsUnsubscribe || liveSessionsUnsubscribe) {
+                liveBadge.textContent = 'LIVE';
+                liveBadge.className = 'status-badge status-confirmed';
+                return;
+            }
+            liveBadge.textContent = 'IDLE';
+            liveBadge.className = 'status-badge status-pending';
+        }
+
+        function clearStoreOpsAccessState() {
+            storeOpsAccess.denied = false;
+            storeOpsAccess.reason = '';
+            storeOpsAccess.source = '';
+            storeOpsAccess.notifiedReason = '';
+            updateStoreOpsAccessUi();
+        }
+
+        function handleStoreOpsAccessError(error, source = '') {
+            const denied = isPermissionDenied(error);
+            if (!denied) return false;
+
+            const reason = String(error && (error.message || error.reason) || error || 'unknown store ops access error').trim();
+            const normalizedSource = String(source || 'store-ops');
+            storeOpsAccess.denied = true;
+            storeOpsAccess.reason = reason;
+            storeOpsAccess.source = normalizedSource;
+
+            if (storeOpsAccess.notifiedReason !== reason) {
+                storeOpsAccess.notifiedReason = reason;
+                showNotification('error', 'تعذر تشغيل المراقبة اللحظية بسبب الصلاحيات. باقي لوحة الأدمن تعمل طبيعي.');
+            }
+
+            warnPermissionDeniedOnce(normalizedSource, error, 'store operations access denied');
+            stopStoreOperationsMonitoring();
+            storeEvents = [];
+            liveSessions = [];
+            renderStoreEventsTable();
+            renderLiveSessionsTable();
+            updateStoreOpsAccessUi();
+            return true;
+        }
+
+        function canUseStoreOps(notify = true) {
+            if (storeOpsAccess.denied) {
+                updateStoreOpsAccessUi();
+                if (notify) {
+                    showNotification('error', 'المراقبة اللحظية متوقفة حاليًا بسبب الصلاحيات.');
+                }
+                return false;
+            }
+            return true;
+        }
+
         function renderStoreEventsTable() {
             const tbody = document.getElementById('storeEventsTable');
             const meta = document.getElementById('storeEventsMeta');
@@ -5851,14 +5995,24 @@ function adminLogout(){
             if (typeof liveSessionsUnsubscribe === 'function') liveSessionsUnsubscribe();
             storeEventsUnsubscribe = null;
             liveSessionsUnsubscribe = null;
+            updateStoreOpsAccessUi();
         }
 
-        function startStoreOperationsMonitoring() {
+        async function startStoreOperationsMonitoring() {
             const liveBadge = document.getElementById('storeOpsLiveBadge');
             if (storeEventsUnsubscribe || liveSessionsUnsubscribe) return;
+            if (!canUseStoreOps(false)) return;
 
             if (typeof subscribeStoreEvents !== 'function' || typeof subscribeLiveSessions !== 'function') {
                 if (liveBadge) liveBadge.textContent = 'N/A';
+                return;
+            }
+
+            try {
+                await requireAdminPermission();
+                clearStoreOpsAccessState();
+            } catch (error) {
+                handleStoreOpsAccessError(error, 'startStoreOperationsMonitoring.requireAdminPermission');
                 return;
             }
 
@@ -5866,21 +6020,35 @@ function adminLogout(){
                 storeEvents = rows || [];
                 renderStoreEventsTable();
             }, (error) => {
-                console.error('store events listener error:', error);
+                if (handleStoreOpsAccessError(error, 'startStoreOperationsMonitoring.storeEventsListener')) return;
+                logWarnOnce(
+                    'startStoreOperationsMonitoring.storeEventsListener.warning',
+                    'store events listener warning:',
+                    String(error && error.message ? error.message : error)
+                );
             }, 100);
 
             liveSessionsUnsubscribe = subscribeLiveSessions((rows) => {
                 liveSessions = rows || [];
                 renderLiveSessionsTable();
             }, (error) => {
-                console.error('live sessions listener error:', error);
+                if (handleStoreOpsAccessError(error, 'startStoreOperationsMonitoring.liveSessionsListener')) return;
+                logWarnOnce(
+                    'startStoreOperationsMonitoring.liveSessionsListener.warning',
+                    'live sessions listener warning:',
+                    String(error && error.message ? error.message : error)
+                );
             }, 200);
 
             if (liveBadge) liveBadge.textContent = 'LIVE';
+            updateStoreOpsAccessUi();
         }
 
         async function refreshStoreOperationsNow() {
+            if (!canUseStoreOps()) return;
             try {
+                await requireAdminPermission();
+                clearStoreOpsAccessState();
                 if (typeof getStoreEvents === 'function') {
                     storeEvents = await getStoreEvents(100) || [];
                 }
@@ -5892,7 +6060,12 @@ function adminLogout(){
                 renderLiveSessionsTable();
                 showNotification('success', 'تم تحديث التشغيل اللحظي');
             } catch (error) {
-                console.error('refreshStoreOperationsNow error:', error);
+                if (handleStoreOpsAccessError(error, 'refreshStoreOperationsNow')) return;
+                logWarnOnce(
+                    'refreshStoreOperationsNow.warning',
+                    'refreshStoreOperationsNow warning:',
+                    String(error && error.message ? error.message : error)
+                );
                 showNotification('error', 'فشل تحديث التشغيل اللحظي');
             }
         }
@@ -5980,6 +6153,8 @@ function adminLogout(){
             const mobileDirectEl = document.getElementById('adminFunctionsMobileDirect');
             const failuresEl = document.getElementById('adminFunctionsFailures');
             const metaEl = document.getElementById('adminFunctionsMeta');
+            const impactSummaryEl = document.getElementById('adminFunctionsImpactSummary');
+            const persistenceSummaryEl = document.getElementById('adminFunctionsPersistenceSummary');
 
             const total = Array.isArray(adminFunctionRegistry) ? adminFunctionRegistry.length : 0;
             const critical = adminFunctionRegistry.filter((item) => item.monitorLevel === 'critical').length;
@@ -5987,6 +6162,14 @@ function adminLogout(){
             const mobileDirect = adminFunctionRegistry.filter((item) => item.mobileImpact === 'direct').length;
             const failures = adminFunctionRegistry.filter((item) => item.status === 'fail').length;
             const filtered = Array.isArray(adminFunctionRegistryFiltered) ? adminFunctionRegistryFiltered.length : 0;
+            const storeIndirect = adminFunctionRegistry.filter((item) => item.storeImpact === 'indirect').length;
+            const storeNone = adminFunctionRegistry.filter((item) => item.storeImpact === 'none').length;
+            const mobileIndirect = adminFunctionRegistry.filter((item) => item.mobileImpact === 'indirect').length;
+            const mobileNone = adminFunctionRegistry.filter((item) => item.mobileImpact === 'none').length;
+            const firebaseOnline = adminFunctionRegistry.filter((item) => item.persistenceMode === 'firebase_online').length;
+            const hybrid = adminFunctionRegistry.filter((item) => item.persistenceMode === 'hybrid').length;
+            const localTemporary = adminFunctionRegistry.filter((item) => item.persistenceMode === 'local_temporary').length;
+            const memoryOnly = adminFunctionRegistry.filter((item) => item.persistenceMode === 'memory_only').length;
 
             if (totalEl) totalEl.textContent = String(total);
             if (criticalEl) criticalEl.textContent = String(critical);
@@ -6002,6 +6185,14 @@ function adminLogout(){
                     ? String(adminFunctionRegistryMeta.generatorVersion)
                     : '-';
                 metaEl.textContent = `الدوال: ${total} | المعروضة: ${filtered} | نسخة المولد: ${generatorVersion} | التوليد: ${generatedAt}`;
+            }
+
+            if (impactSummaryEl) {
+                impactSummaryEl.textContent = `تأثير المتجر (مباشر: ${storeDirect} | غير مباشر: ${storeIndirect} | لا يوجد: ${storeNone}) • تأثير الموبايل (مباشر: ${mobileDirect} | غير مباشر: ${mobileIndirect} | لا يوجد: ${mobileNone})`;
+            }
+
+            if (persistenceSummaryEl) {
+                persistenceSummaryEl.textContent = `نمط الحفظ: Firebase أونلاين ${firebaseOnline} | هجين ${hybrid} | محلي مؤقت ${localTemporary} | ذاكرة فقط ${memoryOnly}`;
             }
         }
 


### PR DESCRIPTION
## Summary
- Admin now degrades per-section on permission denied (Support/Store Ops) without breaking dashboard.
- Firebase subscription errors are normalized before reaching admin handlers.
- Production is now blocked unless firestore rules are deployed for the same SHA.

## Included Changes
- Added deploy-firestore-rules workflow (manual, same-SHA enforced).
- Hardened deploy-production verify-gates to require release-gate + staging + firestore-rules on same SHA.
- Updated admin permission handling UI/state and reduced log spam to one-time warn per source.
- Updated smoke/e2e governance checks and registry artifact updates.

## Governance
- No bypass to production.
- Same-SHA promotion remains mandatory.