### PR TITLE
chore(governance): keyless oidc federation for firestore rules deploy

### DIFF
--- a/.github/workflows/deploy-firestore-rules.yml
+++ b/.github/workflows/deploy-firestore-rules.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: deploy-firestore-rules
@@ -50,29 +51,37 @@ jobs:
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
 
-      - name: Configure Firebase auth
-        id: auth
+      - name: Validate OIDC federation secrets
         env:
-          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
         run: |
           set -euo pipefail
-          if [[ -n "${FIREBASE_SERVICE_ACCOUNT:-}" ]]; then
-            credentials_path="$RUNNER_TEMP/firebase-service-account.json"
-            printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$credentials_path"
-            echo "GOOGLE_APPLICATION_CREDENTIALS=$credentials_path" >> "$GITHUB_ENV"
-            echo "auth_mode=service_account" >> "$GITHUB_OUTPUT"
-            exit 0
+          missing=0
+
+          if [[ -z "${GCP_WORKLOAD_IDENTITY_PROVIDER:-}" ]]; then
+            echo "::error::Missing secret: GCP_WORKLOAD_IDENTITY_PROVIDER"
+            missing=1
           fi
 
-          if [[ -n "${FIREBASE_TOKEN:-}" ]]; then
-            echo "FIREBASE_TOKEN=$FIREBASE_TOKEN" >> "$GITHUB_ENV"
-            echo "auth_mode=firebase_token" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [[ -z "${GCP_SERVICE_ACCOUNT_EMAIL:-}" ]]; then
+            echo "::error::Missing secret: GCP_SERVICE_ACCOUNT_EMAIL"
+            missing=1
           fi
 
-          echo "::error::Missing Firebase credentials. Set FIREBASE_SERVICE_ACCOUNT or FIREBASE_TOKEN secret."
-          exit 1
+          if [[ "$missing" -ne 0 ]]; then
+            echo "::error::Configure GitHub OIDC -> GCP Workload Identity Federation and rerun."
+            echo "::error::Static credential secrets (FIREBASE_SERVICE_ACCOUNT / FIREBASE_TOKEN) are intentionally not used."
+            exit 1
+          fi
+
+      - name: Authenticate to Google Cloud (OIDC/WIF)
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          create_credentials_file: true
 
       - name: Deploy firestore.rules
         env:
@@ -91,5 +100,5 @@ jobs:
             echo "- deployed_rules_file: \`firestore.rules\`"
             echo "- reason: ${{ github.event.inputs.reason }}"
             echo "- timestamp_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-            echo "- auth_mode: ${{ steps.auth.outputs.auth_mode }}"
+            echo "- auth_mode: \`oidc_wif\`"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Replaced firestore rules auth with keyless GitHub OIDC -> Google WIF.
- Removed dependence on FIREBASE_SERVICE_ACCOUNT and FIREBASE_TOKEN.
- Added explicit required secret checks for WIF provider and service account email.

## Required Secrets
- GCP_WORKLOAD_IDENTITY_PROVIDER
- GCP_SERVICE_ACCOUNT_EMAIL
- FIREBASE_PROJECT_ID (optional)