### PR TITLE
fix(workflow): switch firestore rules deploy logic to firebase cli

### DIFF
--- a/.github/workflows/deploy-firestore-rules.yml
+++ b/.github/workflows/deploy-firestore-rules.yml
@@ -177,52 +177,50 @@ jobs:
           gcloud auth list
           gcloud auth list --filter=status:ACTIVE --format="value(account)"
 
-      - name: Deploy Firestore Rules via Firebaserules API
+      - name: Install Firebase CLI
+        run: |
+          set -euo pipefail
+          npm install -g firebase-tools
+
+      - name: Deploy Firestore Rules via Firebase CLI
         id: deploy
         run: |
           set -euo pipefail
           project_id="${{ steps.project.outputs.project_id }}"
           target_sha="${{ github.event.inputs.target_sha }}"
           reason="${{ github.event.inputs.reason }}"
-          access_token="$(gcloud auth print-access-token)"
 
           echo "Project: $project_id"
           echo "SHA: $target_sha"
           echo "Reason: $reason"
-          echo "Deploy method: firebaserules_rest_api"
+          echo "Deploy method: firebase_cli"
 
-          PROJECT_ID="$project_id" ACCESS_TOKEN="$access_token" RULES_FILE="firestore.rules" node - <<'NODE'
+          firebase deploy --only firestore:rules --project "$project_id" --non-interactive
+
+          access_token="$(gcloud auth print-access-token)"
+          PROJECT_ID="$project_id" ACCESS_TOKEN="$access_token" node - <<'NODE'
           const fs = require('fs');
           const https = require('https');
           const projectId = process.env.PROJECT_ID;
           const accessToken = process.env.ACCESS_TOKEN;
-          const rulesFile = process.env.RULES_FILE;
           const outputPath = process.env.GITHUB_OUTPUT;
 
-          if (!projectId || !accessToken || !rulesFile || !outputPath) {
-            console.error('Missing required environment for rules deployment.');
+          if (!projectId || !accessToken || !outputPath) {
+            console.error('Missing required environment for release metadata lookup.');
             process.exit(1);
           }
-          const rulesContent = fs.readFileSync(rulesFile, 'utf8');
-          const releaseName = `projects/${projectId}/releases/cloud.firestore`;
+          const releasePath = `/v1/projects/${projectId}/releases/cloud.firestore`;
 
-          function apiRequest(method, path, body) {
+          function apiGet(path) {
             return new Promise((resolve, reject) => {
-              const payload = body ? JSON.stringify(body) : null;
               const req = https.request(
                 {
                   hostname: 'firebaserules.googleapis.com',
                   path,
-                  method,
+                  method: 'GET',
                   headers: {
                     Authorization: `Bearer ${accessToken}`,
                     Accept: 'application/json',
-                    ...(payload
-                      ? {
-                          'Content-Type': 'application/json',
-                          'Content-Length': Buffer.byteLength(payload),
-                        }
-                      : {}),
                   },
                 },
                 (res) => {
@@ -245,55 +243,32 @@ jobs:
                     }
                     reject(
                       new Error(
-                        `Firebaserules API ${method} ${path} failed (${res.statusCode}): ${raw || '<empty>'}`
+                        `Firebaserules API GET ${path} failed (${res.statusCode}): ${raw || '<empty>'}`
                       )
                     );
                   });
                 }
               );
               req.on('error', reject);
-              if (payload) {
-                req.write(payload);
-              }
               req.end();
             });
           }
 
           async function run() {
-            const createRuleset = await apiRequest('POST', `/v1/projects/${projectId}/rulesets`, {
-              source: {
-                files: [{ name: 'firestore.rules', content: rulesContent }],
-              },
-            });
-
-            const rulesetName = createRuleset.body?.name;
+            const release = await apiGet(releasePath);
+            const rulesetName = release?.rulesetName;
+            const releaseName = release?.name;
             if (!rulesetName) {
-              throw new Error(`Ruleset creation returned no name: ${JSON.stringify(createRuleset.body)}`);
+              throw new Error(`Release metadata missing rulesetName: ${JSON.stringify(release)}`);
+            }
+            if (!releaseName) {
+              throw new Error(`Release metadata missing name: ${JSON.stringify(release)}`);
             }
 
-            let releaseResult = null;
-            try {
-              await apiRequest('GET', `/v1/${releaseName}`);
-              releaseResult = await apiRequest(
-                'PATCH',
-                `/v1/${releaseName}?updateMask=rulesetName`,
-                { name: releaseName, rulesetName }
-              );
-            } catch (err) {
-              if (!String(err.message).includes('(404)')) {
-                throw err;
-              }
-              releaseResult = await apiRequest('POST', `/v1/projects/${projectId}/releases`, {
-                name: releaseName,
-                rulesetName,
-              });
-            }
-
-            const finalReleaseName = releaseResult.body?.name || releaseName;
             fs.appendFileSync(outputPath, `ruleset_name=${rulesetName}\n`);
-            fs.appendFileSync(outputPath, `release_name=${finalReleaseName}\n`);
+            fs.appendFileSync(outputPath, `release_name=${releaseName}\n`);
             console.log(`Ruleset: ${rulesetName}`);
-            console.log(`Release: ${finalReleaseName}`);
+            console.log(`Release: ${releaseName}`);
           }
 
           run().catch((error) => {
@@ -308,7 +283,7 @@ jobs:
           {
             echo "## Firestore Rules Deployment"
             echo "- status: ${{ job.status }}"
-            echo "- auth_mode: oidc_wif_firebaserules_rest_api"
+            echo "- auth_mode: oidc_wif_firebase_cli"
             echo "- auth_strategy: \`${{ steps.auth_mode.outputs.mode }}\`"
             echo "- project_id: ${{ steps.project.outputs.project_id }}"
             echo "- target_sha: \`${{ github.event.inputs.target_sha }}\`"


### PR DESCRIPTION
Deploy-logic-only fix.

- Keep OIDC/WIF auth unchanged
- Keep Same-SHA handling unchanged
- Replace failing Firebaserules PATCH flow with Firebase CLI deploy + release metadata fetch
