### PR TITLE
fix: BANNER-011 root cause — stop Cloudinary pre-cropping

### DIFF
--- a/assets/js/cloudinary-service.js
+++ b/assets/js/cloudinary-service.js
@@ -453,7 +453,7 @@
         break;
       case 'auto':
       default:
-        transform = 'w_' + selectedContext.w + ',c_fill,g_auto,ar_' + selectedContext.ar + ',q_auto:good,f_auto';
+        transform = 'w_' + selectedContext.w + ',c_limit,q_auto:good,f_auto';
         break;
     }
 

--- a/version.json
+++ b/version.json
@@ -1,11 +1,11 @@
 {
-  "version": "2026.04.22.0028",
-  "lastUpdate": "BANNER-010",
+  "version": "2026.04.24.0029",
+  "lastUpdate": "BANNER-011",
   "changes": [
-    "backdrop: تفعيل لكل fitMode ما عدا crop",
-    "backdrop: blur(32px) موحد احترافي",
-    "backdrop: ملء الفراغ الجانبي بنفس ألوان الصورة",
-    "cleanup: إزالة banner-smart-landscape الميت",
-    "dual-layer: صورة واضحة + خلفية ضبابية"
+    "root-fix: إيقاف القص القسري من Cloudinary لـ fitMode auto",
+    "cloudinary: c_limit بدلاً من c_fill — الصورة الأصلية كاملة",
+    "portrait: object-position center center بدلاً من center top",
+    "mobile-portrait: max-height 100vw بدلاً من 85vw (+17.6%)",
+    "impact: Desktop و Mobile يستلمان نفس نسبة الصورة الأصلية"
   ]
 }

--- a/متجر_2.HTML
+++ b/متجر_2.HTML
@@ -433,7 +433,7 @@
         }
 
         .banner-hero.banner-portrait .banner-hero-img {
-            object-position: center top;
+            object-position: center center;
         }
 
         .banner-hero.banner-landscape .banner-hero-img {
@@ -721,7 +721,7 @@
             }
             .banner-hero.banner-portrait {
                 aspect-ratio: 3 / 4;
-                max-height: 85vw;
+                max-height: 100vw;
             }
             .banner-hero.banner-square {
                 aspect-ratio: 1 / 1;


### PR DESCRIPTION
- Cloudinary: c_limit instead of c_fill for fitMode auto
- Portrait: object-position center center
- Mobile portrait: max-height 100vw (+17.6%)
- Fixes: portrait cropped from top + mobile too short

BREAKING: Modifies protected cloudinary-service.js
APPROVED: Owner granted explicit permission

## Summary
<!-- What does this PR do? -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Governance/tooling
- [ ] Data migration
- [ ] Refactor

## Files Changed
<!-- List files and why each was changed -->

## Governance Checklist
- [ ] Ran npm run preflight before starting
- [ ] Used clean worktree (no dirty files)
- [ ] smoke-check: PASS
- [ ] contracts-check: PASS
- [ ] admin-function-monitor: PASS
- [ ] version.json bumped (if sensitive files changed)
- [ ] No Required checks removed
- [ ] No direct push to main
- [ ] Release Gate green before requesting merge

## Impact Assessment
- [ ] Breaking changes: YES / NO
- [ ] Firestore schema changes: YES / NO
- [ ] Auth/security changes: YES / NO
- [ ] Backend API changes: YES / NO (should always be NO on Spark)
- [ ] Sensitive files changed: YES / NO

## Testing
<!-- How was this tested? -->
- [ ] Tested locally
- [ ] Tested on GitHub Pages preview
- [ ] Admin dashboard verified
- [ ] Store frontend verified

## Notes for Reviewer
<!-- Anything the reviewer should know -->
